### PR TITLE
(maint) Change GitLab settings to GitHub for teamcity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -67,9 +67,9 @@ object ChocolateyCommunityValidation : BuildType({
 
     features {
         pullRequests {
-            provider = gitlab {
+            provider = github {
                 authType = token {
-                    token = "%system.GitLabPAT%"
+                    token = "%system.GitHubPAT%"
                 }
             }
         }


### PR DESCRIPTION
## Description Of Changes

This updates the tokens and providers used by teamcity
to be the GitHub provider, instead of the GitLab provider.

## Motivation and Context

To use the correct information to build on teamcity

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build Related

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A