### PR TITLE
(#26) Use milestone for license URL replacement

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -41,7 +41,7 @@ Task("Prepare-Chocolatey-Packages")
         "https://github.com/{0}/{1}/blob/{2}/LICENSE.txt",
         BuildParameters.RepositoryOwner,
         BuildParameters.RepositoryName,
-        BuildParameters.BuildProvider.Repository.Tag.IsTag ? BuildParameters.BuildProvider.Repository.Tag.Name : BuildParameters.BuildProvider.Repository.Branch
+        BuildParameters.BuildProvider.Repository.Tag.IsTag ? BuildParameters.Version.Milestone : BuildParameters.BuildProvider.Repository.Branch
     );
 
     var verificationText = string.Format(@"


### PR DESCRIPTION
## Description Of Changes

This updates the relpacement used when creating a license URL
to make use of the Build Version Milestone, instead of the tag name.

## Motivation and Context

This is done as in certain scenarios the tag name is an empty string and will
cause an invalid URL to be generated. This causes problems when doing a
release of the product, and thus changing to the milestone is more
appropriate.

## Testing

1. Create a temporary tag locally
2. Run the build using ´build.bat´
3. Verify the created package has the correct license URL (with the name of the tag in the URL)

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change) (Build Related).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #26

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
