### PR TITLE
(#32) Update Help URLs to short links

### DIFF
--- a/src/Chocolatey.Community.Validation.Tests/Rules/AnyElementRulesTests.ShouldFlagAllElementsInADefaultTemplate.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/AnyElementRulesTests.ShouldFlagAllElementsInADefaultTemplate.verified.txt
@@ -1,48 +1,48 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'version' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'owners' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'authors' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'iconUrl' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'tags' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'summary' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'description' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019,
+    HelpUrl: https://ch0.co/rules/cpmr0019,
     Id: CPMR0019,
     Message: The element 'releaseNotes' contained a templated value. Templated values should not be present in the Metadata file.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/AnyElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/AnyElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0019,
     Summary: Templated values should not be present in Metadata file.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0019
+    HelpUrl: https://ch0.co/rules/cpmr0019
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=    .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=    .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=  uba   .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=  uba   .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=--  -.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=--  -.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=a.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=a.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=abc.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=abc.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldFlagWhenCopyrightIsBelow4Characters_copyright=null.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001,
+    HelpUrl: https://ch0.co/rules/cpmr0001,
     Id: CPMR0001,
     Message: Copyright Character Count Below 4 characters,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/CopyrightElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0001,
     Summary: Copyright Character Count Below 4 characters,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0001
+    HelpUrl: https://ch0.co/rules/cpmr0001
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWhileMissingDependenciesElement.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWhileMissingDependenciesElement.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0017,
+    HelpUrl: https://ch0.co/rules/cpmr0017,
     Id: CPMR0017,
     Message: A dependency is required for deprecated packages.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWithoutDependenciesListed.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWithoutDependenciesListed.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0017,
+    HelpUrl: https://ch0.co/rules/cpmr0017,
     Id: CPMR0017,
     Message: A dependency is required for deprecated packages.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWithoutDependenciesThatIsSelfClosed.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagWhenTitleContainsDeprecatedWithoutDependenciesThatIsSelfClosed.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0017,
+    HelpUrl: https://ch0.co/rules/cpmr0017,
     Id: CPMR0017,
     Message: A dependency is required for deprecated packages.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0017,
     Summary: Deprecated packages must have a dependency.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0017
+    HelpUrl: https://ch0.co/rules/cpmr0017
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=######Heading 6.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=######Heading 6.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=#####Heading 5.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=#####Heading 5.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=####Heading 4.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=####Heading 4.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=###Heading 3.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=###Heading 3.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=##Heading 2.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=##Heading 2.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=#Heading 1.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=#Heading 1.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---######Heading 6.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---######Heading 6.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---#####Heading 5.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---#####Heading 5.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---####Heading 4.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---####Heading 4.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---###Heading 3.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---###Heading 3.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---##Heading 2.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---##Heading 2.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---#Heading 1.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionContainsInvalidMarkdownHeaders_description=---#Heading 1.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030,
+    HelpUrl: https://ch0.co/rules/cpmr0030,
     Id: CPMR0030,
     Message: The description of the package contains invalid Markdown Headings.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionElementIsNotPresent.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionElementIsNotPresent.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002,
+    HelpUrl: https://ch0.co/rules/cpmr0002,
     Id: CPMR0002,
     Message: A description of the package is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionHasMoreThan4000Characters.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionHasMoreThan4000Characters.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0026,
+    HelpUrl: https://ch0.co/rules/cpmr0026,
     Id: CPMR0026,
     Message: The description has a length of 4,060 characters. A description can not have a length of above 4,000 characters.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=     .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=     .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002,
+    HelpUrl: https://ch0.co/rules/cpmr0002,
     Id: CPMR0002,
     Message: A description of the package is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=--   -.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=--   -.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002,
+    HelpUrl: https://ch0.co/rules/cpmr0002,
     Id: CPMR0002,
     Message: A description of the package is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002,
+    HelpUrl: https://ch0.co/rules/cpmr0002,
     Id: CPMR0002,
     Message: A description of the package is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsEmpty_value=null.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002,
+    HelpUrl: https://ch0.co/rules/cpmr0002,
     Id: CPMR0002,
     Message: A description of the package is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsExactly30Characters.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsExactly30Characters.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0032,
+    HelpUrl: https://ch0.co/rules/cpmr0032,
     Id: CPMR0032,
     Message: The description has a length of 30 characters. A description should be sufficient to explain the software.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsLessThan30Characters.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsLessThan30Characters.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0032,
+    HelpUrl: https://ch0.co/rules/cpmr0032,
     Id: CPMR0032,
     Message: The description has a length of 22 characters. A description should be sufficient to explain the software.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsLessThan30CharactersAfterTrimming.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldFlagWhenDescriptionIsLessThan30CharactersAfterTrimming.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0032,
+    HelpUrl: https://ch0.co/rules/cpmr0032,
     Id: CPMR0032,
     Message: The description has a length of 21 characters. A description should be sufficient to explain the software.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DescriptionElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,24 +3,24 @@
     Severity: Error,
     Id: CPMR0002,
     Summary: A description of the package is either missing or empty.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0002
+    HelpUrl: https://ch0.co/rules/cpmr0002
   },
   {
     Severity: Error,
     Id: CPMR0026,
     Summary: A description can not have a length of above 4,000 characters.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0026
+    HelpUrl: https://ch0.co/rules/cpmr0026
   },
   {
     Severity: Error,
     Id: CPMR0030,
     Summary: The description of the package contains invalid Markdown Headings.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0030
+    HelpUrl: https://ch0.co/rules/cpmr0030
   },
   {
     Severity: Error,
     Id: CPMR0032,
     Summary: The description is not sufficient to explain the software.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0032
+    HelpUrl: https://ch0.co/rules/cpmr0032
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=beta-test.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=beta-test.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=my prerelease.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=my prerelease.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=my-package.CONFIG.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=my-package.CONFIG.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0029,
+    HelpUrl: https://ch0.co/rules/cpmr0029,
     Id: CPMR0029,
     Message: Package ID ends with the reserved suffix `.config`.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=pkg.config.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=pkg.config.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0029,
+    HelpUrl: https://ch0.co/rules/cpmr0029,
     Id: CPMR0029,
     Message: Package ID ends with the reserved suffix `.config`.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=prerelease.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=prerelease.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=test-ALPha.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=test-ALPha.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=testBETA.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=testBETA.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=testalpha.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=testalpha.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024,
+    HelpUrl: https://ch0.co/rules/cpmr0024,
     Id: CPMR0024,
     Message: Package ID includes a prerelease version name.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,12 +3,12 @@
     Severity: Error,
     Id: CPMR0024,
     Summary: Package ID includes a prerelease version name.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0024
+    HelpUrl: https://ch0.co/rules/cpmr0024
   },
   {
     Severity: Error,
     Id: CPMR0029,
     Summary: Package ID ends with the reserved suffix `.config`.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0029
+    HelpUrl: https://ch0.co/rules/cpmr0029
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagAllEmailsInNuspec_outputEmails=False.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagAllEmailsInNuspec_outputEmails=False.verified.txt
@@ -1,132 +1,132 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'id' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'version' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'packageSourceUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'owners' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'title' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'authors' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'projectUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'iconUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'copyright' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'licenseUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'projectSourceUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'docsUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'mailingListUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'bugTrackerUrl' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'tags' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'summary' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'description' contains 3 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'releaseNotes' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'language' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'provides' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'conflicts' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'replaces' contains 1 email(s). Emails should not be present in the Metadata file.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagAllEmailsInNuspec_outputEmails=True.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagAllEmailsInNuspec_outputEmails=True.verified.txt
@@ -1,132 +1,132 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'id' contained the emails 'bobbbbb@te.st'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'version' contained the emails 'abc@def.gh'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'packageSourceUrl' contained the emails 'package-source@test.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'owners' contained the emails 'owner@my-email.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'title' contained the emails 'Bob@test.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'authors' contained the emails 'bob@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'projectUrl' contained the emails 'project@test.nz'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'iconUrl' contained the emails 'icon@bob.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'copyright' contained the emails 'bob@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'licenseUrl' contained the emails 'bob@test.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'projectSourceUrl' contained the emails 'pkg-source@test.no'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'docsUrl' contained the emails 'bob@bob2.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'mailingListUrl' contained the emails 'bob@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'bugTrackerUrl' contained the emails 'bob@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'tags' contained the emails 'bobby@bob.no'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'summary' contained the emails 'BOB@test.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'description' contained the emails 'bob@bob.co.uk, lezy@workplace.com, someone@worker.no'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'releaseNotes' contained the emails 'awesome@user.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'language' contained the emails 'bob@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'provides' contained the emails 'provides@test.com'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'conflicts' contained the emails 'bob+label@bob.co.uk'. Emails should not be present in the Metadata file.,
     Severity: Error
   },
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: The element 'replaces' contained the emails 'bobby@bobtastic.ca'. Emails should not be present in the Metadata file.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagEmailUsedOutsideOfMetadataFields.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldFlagEmailUsedOutsideOfMetadataFields.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020,
+    HelpUrl: https://ch0.co/rules/cpmr0020,
     Id: CPMR0020,
     Message: An Email Address should not be used in Metadata file.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/NuspecContainsEmailsRuleTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0020,
     Summary: An Email Address should not be used in Metadata file.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0020
+    HelpUrl: https://ch0.co/rules/cpmr0020
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlElementIsNotPresent.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlElementIsNotPresent.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009,
+    HelpUrl: https://ch0.co/rules/cpmr0009,
     Id: CPMR0009,
     Message: A project URL for the software is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=    .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=    .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009,
+    HelpUrl: https://ch0.co/rules/cpmr0009,
     Id: CPMR0009,
     Message: A project URL for the software is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=--  -.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=--  -.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009,
+    HelpUrl: https://ch0.co/rules/cpmr0009,
     Id: CPMR0009,
     Message: A project URL for the software is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009,
+    HelpUrl: https://ch0.co/rules/cpmr0009,
     Id: CPMR0009,
     Message: A project URL for the software is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldFlagWhenProjectUrlIsEmpty_value=null.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009,
+    HelpUrl: https://ch0.co/rules/cpmr0009,
     Id: CPMR0009,
     Message: A project URL for the software is either missing or empty.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/ProjectUrlElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0009,
     Summary: A project URL for the software is either missing or empty.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0009
+    HelpUrl: https://ch0.co/rules/cpmr0009
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndLicenseUrlIsMissing.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndLicenseUrlIsMissing.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0007,
+    HelpUrl: https://ch0.co/rules/cpmr0007,
     Id: CPMR0007,
     Message: The license URL is absent, despite the requirement for license acceptance.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=     .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=     .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0007,
+    HelpUrl: https://ch0.co/rules/cpmr0007,
     Id: CPMR0007,
     Message: The license URL is absent, despite the requirement for license acceptance.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0007,
+    HelpUrl: https://ch0.co/rules/cpmr0007,
     Id: CPMR0007,
     Message: The license URL is absent, despite the requirement for license acceptance.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldFlagWhenLicenseAcceptanceIsTrueAndNoLicenseUrl_value=null.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0007,
+    HelpUrl: https://ch0.co/rules/cpmr0007,
     Id: CPMR0007,
     Message: The license URL is absent, despite the requirement for license acceptance.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/RequireLicenceAcceptanceElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,6 +3,6 @@
     Severity: Error,
     Id: CPMR0007,
     Summary: The license URL is absent, despite the requirement for license acceptance.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0007
+    HelpUrl: https://ch0.co/rules/cpmr0007
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=,taggie.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=,taggie.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0014,
+    HelpUrl: https://ch0.co/rules/cpmr0014,
     Id: CPMR0014,
     Message: The tags have been separated by a comma; they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=tag1, tag2 tag3.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=tag1, tag2 tag3.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0014,
+    HelpUrl: https://ch0.co/rules/cpmr0014,
     Id: CPMR0014,
     Message: The tags have been separated by a comma; they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=taggie,.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=taggie,.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0014,
+    HelpUrl: https://ch0.co/rules/cpmr0014,
     Id: CPMR0014,
     Message: The tags have been separated by a comma; they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=    .verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=    .verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023,
+    HelpUrl: https://ch0.co/rules/cpmr0023,
     Id: CPMR0023,
     Message: Packages require at least one tag, and they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=--  -.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=--  -.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023,
+    HelpUrl: https://ch0.co/rules/cpmr0023,
     Id: CPMR0023,
     Message: Packages require at least one tag, and they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023,
+    HelpUrl: https://ch0.co/rules/cpmr0023,
     Id: CPMR0023,
     Message: Packages require at least one tag, and they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagEmptyTags_tags=null.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023,
+    HelpUrl: https://ch0.co/rules/cpmr0023,
     Id: CPMR0023,
     Message: Packages require at least one tag, and they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagMissingTagsElement.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagMissingTagsElement.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023,
+    HelpUrl: https://ch0.co/rules/cpmr0023,
     Id: CPMR0023,
     Message: Packages require at least one tag, and they must be separated by a space.,
     Severity: Error

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -3,12 +3,12 @@
     Severity: Error,
     Id: CPMR0014,
     Summary: The tags have been separated by a comma; they must be separated by a space.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0014
+    HelpUrl: https://ch0.co/rules/cpmr0014
   },
   {
     Severity: Error,
     Id: CPMR0023,
     Summary: Packages require at least one tag, and they must be separated by a space.,
-    HelpUrl: https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0023
+    HelpUrl: https://ch0.co/rules/cpmr0023
   }
 ]

--- a/src/Chocolatey.Community.Validation/Rules/CCRMetadataRuleBase.cs
+++ b/src/Chocolatey.Community.Validation/Rules/CCRMetadataRuleBase.cs
@@ -18,7 +18,7 @@ namespace Chocolatey.Community.Validation.Rules
                 }
                 else
                 {
-                    var helpUrl = $"https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/{id!.ToLowerInvariant()}";
+                    var helpUrl = $"https://ch0.co/rules/{id!.ToLowerInvariant()}";
                     yield return new ImmutableRule(severity, id, summary, helpUrl);
                 }
             }


### PR DESCRIPTION
## Description Of Changes

This updates all the URLs shown when a rule fais the validation to use
ch0.co shortlink instead of the full URL to the documentation site.

## Motivation and Context

Using a full URL when outputting in the console uses unnecessary screenspace, and using a short link allows us more customizability if there is a need for it in the future.

## Testing

1. Run `choco new default`.
2. With the extension installed, run `choco pack <PATH_TO_NUSPEC>` with the path to the created package.
3. Verify all URLs outputted in the console uses the `ch0.co` shortlink.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #32