### PR TITLE
(#29) Add missing release notes to generated packages

### DIFF
--- a/nuspec/Chocolatey/chocolatey-community-validation.extension/chocolatey-community-validation.extension.nuspec
+++ b/nuspec/Chocolatey/chocolatey-community-validation.extension/chocolatey-community-validation.extension.nuspec
@@ -31,7 +31,7 @@ The implemented rules will run when creating a package, and when pushing a packa
 
 - Only metadata/nuspec rules are currently supported.
 </description>
-    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
+    <releaseNotes>https://github.com/chocolatey-community/chocolatey-community-validation/releases/tags/$version$</releaseNotes>
 
     <dependencies>
       <!-- We only specify the minimum version, as even breaking changes in Chocolatey CLI is unlikely to relate to the usages in this package -->


### PR DESCRIPTION
## Description Of Changes

This adds a version substitution to the nuspec file to automatically
insert the version to the release notes link when a package is
generated.

## Motivation and Context

We want to have a link to the release notes when we push a package to the Chocolatey Community Repository.

## Testing

1. Run `.\build.ps1`.
2. Navigate to `code_drop\Packages\Chocolatey`.
3. Extract the nupkg file.
4. Open up the nuspec file.
5. Ensure that the release notes element have the version number specified in the URL.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #29