### PR TITLE
(#35) Implement note rule CPMR0062

### DIFF
--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=2.0.0.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=2.0.0.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0062,
+    Id: CPMR0062,
+    Message: A dependency on Chocolatey CLI was found. Ensure that you use functionality that requires the specified version range of Chocolatey CLI.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[,2.0.0).verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[,2.0.0).verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0062,
+    Id: CPMR0062,
+    Message: A dependency on Chocolatey CLI was found. Ensure that you use functionality that requires the specified version range of Chocolatey CLI.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[2.0.0, 3.0.0).verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[2.0.0, 3.0.0).verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0062,
+    Id: CPMR0062,
+    Message: A dependency on Chocolatey CLI was found. Ensure that you use functionality that requires the specified version range of Chocolatey CLI.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[2.0.0,].verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=[2.0.0,].verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0062,
+    Id: CPMR0062,
+    Message: A dependency on Chocolatey CLI was found. Ensure that you use functionality that requires the specified version range of Chocolatey CLI.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=null.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldFlagDependencyOnChocolatey_id=chocolatey_version=null.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0062,
+    Id: CPMR0062,
+    Message: An open ended dependency on Chocolatey CLI was found. Ensure this was not added by a mistake.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -4,5 +4,11 @@
     Id: CPMR0017,
     Summary: Deprecated packages must have a dependency.,
     HelpUrl: https://ch0.co/rules/cpmr0017
+  },
+  {
+    Severity: Note,
+    Id: CPMR0062,
+    Summary: A dependency on Chocolatey CLI has been added.,
+    HelpUrl: https://ch0.co/rules/cpmr0062
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.cs
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/DependenciesElementRulesTests.cs
@@ -8,6 +8,18 @@ namespace Chocolatey.Community.Validation.Tests.Rules
     [Category("Requirements")]
     public class DependenciesElementRulesTests : RuleTestBase<DependenciesElementRules>
     {
+        [TestCase("chocolatey", null)]
+        [TestCase("chocolatey", "2.0.0")]
+        [TestCase("chocolatey", "[,2.0.0)")]
+        [TestCase("chocolatey", "[2.0.0, 3.0.0)")]
+        [TestCase("chocolatey", "[2.0.0,]")]
+        public async Task ShouldFlagDependencyOnChocolatey(string id, string version)
+        {
+            var testContent = GetTestContent("Test Package", (id, version));
+
+            await VerifyNuspec(testContent);
+        }
+
         [Test]
         public async Task ShouldFlagWhenTitleContainsDeprecatedWhileMissingDependenciesElement()
         {


### PR DESCRIPTION
## Description Of Changes

This implements the note rule CPMR0062 - Chocolatey Dependency, which
checks if there is a dependency on Chocolatey CLI defined in the nuspec
file.

## Motivation and Context

This is checked as normally there is no need to define Chocolatey
CLI as a dependency, unless a specific feature is being used. As such,
it is considered to be an anti-pattern to define one.

## Testing

1. Create a new nuspec file.
2. Add a dependency on the package `chocolatey` in the nuspec file
3. Attempt to run `choco pack` on the nuspec file.
4. Ensure a informational message about the rule CPMR0062 is shown.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation (In chocolatey/docs repository).
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #35