### PR TITLE
(#34) Implement note rule CPMR0061 - Id Contains "."

### DIFF
--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=different.something.commandline.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=different.something.commandline.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.extension.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.extension.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.install.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.install.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.portable.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.portable.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.powershell.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.powershell.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.template.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.template.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=something.other.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0061,
+    Id: CPMR0061,
+    Message: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -10,5 +10,11 @@
     Id: CPMR0029,
     Summary: Package ID ends with the reserved suffix `.config`.,
     HelpUrl: https://ch0.co/rules/cpmr0029
+  },
+  {
+    Severity: Note,
+    Id: CPMR0061,
+    Summary: Package ID contains dots (.), that is not part of the accepted suffixes.,
+    HelpUrl: https://ch0.co/rules/cpmr0061
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.cs
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.cs
@@ -7,6 +7,22 @@ namespace Chocolatey.Community.Validation.Tests.Rules
 
     public class IdElementRulesTests : RuleTestBase<IdElementRules>
     {
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("some-id")]
+        [TestCase("something.portable")]
+        [TestCase("something.commandline")]
+        [TestCase("something.powershell")]
+        [TestCase("something.install")]
+        [TestCase("something.template")]
+        [TestCase("something.extension")]
+        public async Task ShouldNotFlagIdentifier(string id)
+        {
+            var testContent = GetTestContent(id);
+
+            await VerifyEmptyResults(testContent);
+        }
+
         [TestCase("testalpha")]
         [TestCase("test-ALPha")]
         [TestCase("testBETA")]
@@ -15,27 +31,18 @@ namespace Chocolatey.Community.Validation.Tests.Rules
         [TestCase("my prerelease")]
         [TestCase("my-package.CONFIG")]
         [TestCase("pkg.config")]
+        [TestCase("something.other")]
+        [TestCase("something.other.portable")]
+        [TestCase("different.something.commandline")]
+        [TestCase("something.other.powershell")]
+        [TestCase("something.other.install")]
+        [TestCase("something.other.template")]
+        [TestCase("something.other.extension")]
         public async Task ShouldFlagIdentifier(string id)
         {
             var testContent = GetTestContent(id);
 
             await VerifyNuspec(testContent);
-        }
-
-        [Test]
-        public async Task ShouldNotFlagIdentifierWithoutPrereleaseName()
-        {
-            var testContent = GetTestContent("some-id");
-
-            await VerifyEmptyResults(testContent);
-        }
-
-        [Test]
-        public async Task ShouldNotFlagAnEmptyIdentifier()
-        {
-            var testContent = GetTestContent(string.Empty);
-
-            await VerifyEmptyResults(testContent);
         }
 
         private static string GetTestContent(string? id)

--- a/src/Chocolatey.Community.Validation/Rules/IdElementRules.cs
+++ b/src/Chocolatey.Community.Validation/Rules/IdElementRules.cs
@@ -7,8 +7,9 @@ namespace Chocolatey.Community.Validation.Rules
 
     public sealed class IdElementRules : CCRMetadataRuleBase
     {
-        private const string PreReleaseRuleId = "CPMR0024";
         private const string ConfigRuleId = "CPMR0029";
+        private const string DotsInIdentifierRuleId = "CPMR0061";
+        private const string PreReleaseRuleId = "CPMR0024";
 
         public override IEnumerable<RuleResult> Validate(global::NuGet.Packaging.NuspecReader reader)
         {
@@ -35,12 +36,45 @@ namespace Chocolatey.Community.Validation.Rules
             {
                 yield return GetRule(ConfigRuleId);
             }
+
+            var subId = GetSubIdentifier(id);
+
+            if (subId.IndexOf('.') > -1)
+            {
+                yield return GetRule(DotsInIdentifierRuleId);
+            }
         }
 
         protected internal override IEnumerable<(RuleType severity, string? id, string summary)> GetRulesInformation()
         {
             yield return (RuleType.Error, PreReleaseRuleId, "Package ID includes a prerelease version name.");
             yield return (RuleType.Error, ConfigRuleId, "Package ID ends with the reserved suffix `.config`.");
+            yield return (RuleType.Note, DotsInIdentifierRuleId, "Package ID contains dots (.), that is not part of the accepted suffixes.");
+        }
+
+        private static string GetSubIdentifier(string id)
+        {
+            var possibleSuffixes = new[]
+            {
+                ".portable",
+                ".commandline",
+                ".install",
+                ".extension",
+                ".template",
+                ".powershell",
+                // This is not an accepted suffix, but an existing rule aready handle this. So we ignore it.
+                ".config"
+            };
+
+            foreach (var suffix in possibleSuffixes)
+            {
+                if (id.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return id.Substring(0, id.Length - suffix.Length);
+                }
+            }
+
+            return id;
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

This implements the note rule CPMR0061 that verifies whether a package
uses a dot in its identifier, which is not recommended to do unless
absolutely necessary.

This implementation is more comprehensive than what is implemented in
package validator, where package validator will have false negatives
that this implementation will properly flag.

## Motivation and Context

We want to implement as many rules as we can that is currently handled by package validator.

## Testing

THis is mostly covered by unit tests, but can be manually verified by

1. Create a new package with a `.` in its identifier.
2. Attempt to run `choco pack` on the created nuspec file.
3. Verify the rule `CPMR0061` is shown.
4. Rename the identifier to end with `.install`, but keep the other `.` in its identifier.
5. Attempt to run `choco pack` on the nuspec file again.
6. Verify the rule `CPMR0061` is shown.
7. Rename the identifier again to remove the extra `.` in the identifier, but keep `.install`.
8. Attempt to run `choco pack` on the nuspec file.
9. Verify the rule `CPMR0061` is no longer displayed.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated (_no documentation needed to be updated_).
* [x] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #34