### PR TITLE
(#39) Add rule for validating underscore in ID

### DIFF
--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=with_underscores.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldFlagIdentifier_id=with_underscores.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0070,
+    Id: CPMR0070,
+    Message: Package ID contains underscores (_). Normally a Package ID is separated by dashes (-).,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -16,5 +16,11 @@
     Id: CPMR0061,
     Summary: Package ID contains dots (.), that is not part of the accepted suffixes.,
     HelpUrl: https://ch0.co/rules/cpmr0061
+  },
+  {
+    Severity: Note,
+    Id: CPMR0070,
+    Summary: Package ID contains underscores (_). Normally a Package ID is separated by dashes (-).,
+    HelpUrl: https://ch0.co/rules/cpmr0070
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.cs
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/IdElementRulesTests.cs
@@ -38,6 +38,7 @@ namespace Chocolatey.Community.Validation.Tests.Rules
         [TestCase("something.other.install")]
         [TestCase("something.other.template")]
         [TestCase("something.other.extension")]
+        [TestCase("with_underscores")]
         public async Task ShouldFlagIdentifier(string id)
         {
             var testContent = GetTestContent(id);

--- a/src/Chocolatey.Community.Validation/Rules/IdElementRules.cs
+++ b/src/Chocolatey.Community.Validation/Rules/IdElementRules.cs
@@ -10,6 +10,7 @@ namespace Chocolatey.Community.Validation.Rules
         private const string ConfigRuleId = "CPMR0029";
         private const string DotsInIdentifierRuleId = "CPMR0061";
         private const string PreReleaseRuleId = "CPMR0024";
+        private const string UnderscoreRuleId = "CPMR0070";
 
         public override IEnumerable<RuleResult> Validate(global::NuGet.Packaging.NuspecReader reader)
         {
@@ -37,6 +38,11 @@ namespace Chocolatey.Community.Validation.Rules
                 yield return GetRule(ConfigRuleId);
             }
 
+            if (id.IndexOf('_') >= 0)
+            {
+                yield return GetRule(UnderscoreRuleId);
+            }
+
             var subId = GetSubIdentifier(id);
 
             if (subId.IndexOf('.') > -1)
@@ -50,6 +56,7 @@ namespace Chocolatey.Community.Validation.Rules
             yield return (RuleType.Error, PreReleaseRuleId, "Package ID includes a prerelease version name.");
             yield return (RuleType.Error, ConfigRuleId, "Package ID ends with the reserved suffix `.config`.");
             yield return (RuleType.Note, DotsInIdentifierRuleId, "Package ID contains dots (.), that is not part of the accepted suffixes.");
+            yield return (RuleType.Note, UnderscoreRuleId, "Package ID contains underscores (_). Normally a Package ID is separated by dashes (-).");
         }
 
         private static string GetSubIdentifier(string id)


### PR DESCRIPTION
## Description Of Changes

This implements the note rule CPMR0070 that validates that a package identifier does not contain an underscore.

## Motivation and Context

To improve the areas that this extension covers compared to package validator.

## Testing

1. Run `choco new test_package`.
2. Update the nuspec content by removing all template values.
3. Update required fields to have a valid value (Version, ProjectUrl, Description, etc).
4. Attempt to run `choco pack` on the nuspec file.
5. Ensure that the rule `CPMR0070` is flagged and shown in the console.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #39
