### PR TITLE
(#36) Add rule for validating usage of `notSilent` tag

### DIFF
--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=NOTSILENT.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldFlagCommaSeparatedTags_tags=NOTSILENT.verified.txt
@@ -1,0 +1,8 @@
+﻿[
+  {
+    HelpUrl: https://ch0.co/rules/cpmr0067,
+    Id: CPMR0067,
+    Message: The tag 'notSilent' is being used.,
+    Severity: Note
+  }
+]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.ShouldReturnAvailableRulesForImplementation.verified.txt
@@ -10,5 +10,11 @@
     Id: CPMR0023,
     Summary: Packages require at least one tag, and they must be separated by a space.,
     HelpUrl: https://ch0.co/rules/cpmr0023
+  },
+  {
+    Severity: Note,
+    Id: CPMR0067,
+    Summary: The tag 'notSilent' is being used.,
+    HelpUrl: https://ch0.co/rules/cpmr0067
   }
 ]

--- a/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.cs
+++ b/src/Chocolatey.Community.Validation.Tests/Rules/TagsElementRulesTests.cs
@@ -5,12 +5,14 @@ namespace Chocolatey.Community.Validation.Tests.Rules
     using Chocolatey.Community.Validation.Rules;
     using NUnit.Framework;
 
-    [Category("Requirements")]
     public class TagsElementRulesTests : RuleTestBase<TagsElementRules>
     {
-        [TestCase(",taggie")]
-        [TestCase("taggie,")]
-        [TestCase("tag1, tag2 tag3")]
+        [TestCase(",taggie", Category = "Requirements")]
+        [TestCase("taggie,", Category = "Requirements")]
+        [TestCase("tag1, tag2 tag3", Category = "Requirements")]
+        [TestCase("notSilent", Category = "Notes")]
+        [TestCase("notsilent", Category = "Notes")]
+        [TestCase("NOTSILENT", Category = "Notes")]
         public async Task ShouldFlagCommaSeparatedTags(string tags)
         {
             var testContent = GetTestContent(tags);
@@ -18,6 +20,7 @@ namespace Chocolatey.Community.Validation.Tests.Rules
             await VerifyNuspec(testContent);
         }
 
+        [Category("Requirements")]
         [TestCaseSource(nameof(EmptyTestValues))]
         public async Task ShouldFlagEmptyTags(string tags)
         {
@@ -27,6 +30,7 @@ namespace Chocolatey.Community.Validation.Tests.Rules
         }
 
         [Test]
+        [Category("Requirements")]
         public async Task ShouldFlagMissingTagsElement()
         {
             const string testContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -48,6 +52,7 @@ namespace Chocolatey.Community.Validation.Tests.Rules
         }
 
         [Test]
+        [Category("Requirements")]
         public async Task ShouldNotFlagTagsNotContainingAComma()
         {
             var testContent = GetTestContent("awesome-tag with space separated");
@@ -56,6 +61,7 @@ namespace Chocolatey.Community.Validation.Tests.Rules
         }
 
         [Test]
+        [Category("Requirements")]
         public async Task ShouldNotFlagWhenTagsIsNotEmpty()
         {
             var testContent = GetTestContent("some awesome tags");

--- a/src/Chocolatey.Community.Validation/Rules/TagsElementRules.cs
+++ b/src/Chocolatey.Community.Validation/Rules/TagsElementRules.cs
@@ -9,6 +9,7 @@ namespace Chocolatey.Community.Validation.Rules
     {
         private const string CommaRuleId = "CPMR0014";
         private const string EmptyRuleId = "CPMR0023";
+        private const string NotSilentRuleId = "CPMR0067";
 
         public override IEnumerable<RuleResult> Validate(global::NuGet.Packaging.NuspecReader reader)
         {
@@ -27,12 +28,18 @@ namespace Chocolatey.Community.Validation.Rules
             {
                 yield return GetRule(CommaRuleId);
             }
+
+            if (tags.IndexOf("notSilent", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                yield return GetRule(NotSilentRuleId);
+            }
         }
 
         protected internal override IEnumerable<(RuleType severity, string? id, string summary)> GetRulesInformation()
         {
             yield return (RuleType.Error, CommaRuleId, "The tags have been separated by a comma; they must be separated by a space.");
             yield return (RuleType.Error, EmptyRuleId, "Packages require at least one tag, and they must be separated by a space.");
+            yield return (RuleType.Note, NotSilentRuleId, "The tag 'notSilent' is being used.");
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

This implements a new note rule for CPMR0067 that checks if the tag
`notSilent` has been used or not.

## Motivation and Context

We want to cover as many rules as we can that is currently implemented in Package Validator.

## Testing

1. Create a nuspec file.
2. Update the `tags` element to contain the tag `notSilent`
3. Run `choco pack` on the created nuspec file.
4. Verify the rule `CPMR0067` is flagged.
5. Repeat previous steps with different letter casing.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #36