### PR TITLE
(maint) Set explicit PlatformTarget for console

### DIFF
--- a/src/Chocolatey.Community.Validation.Console/Chocolatey.Community.Validation.Console.csproj
+++ b/src/Chocolatey.Community.Validation.Console/Chocolatey.Community.Validation.Console.csproj
@@ -12,6 +12,7 @@
     <OutputType>Exe</OutputType>
     <Configurations>Debug;Release;DebugOfficial;ReleaseOfficial</Configurations>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionVersion.cs" Link="SolutionVersion.cs" />


### PR DESCRIPTION
## Description Of Changes

Due to a change in the .NET 9 framework that is being used when running
the Cake Build script, we started having failures due to a missing
target framework.

This was found to be easily fixed by setting the PlatformTarget to
AnyCPU explicitly.

## Motivation and Context

To keep the GHA builds running.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A